### PR TITLE
[#1][Refactor] 비즈니스 로직 분리 및 커스텀 훅 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,6 @@
-import React, { useReducer, useEffect, useState, useRef } from "react";
+import React, { useReducer, useEffect, useRef } from "react";
 import "./App.css";
-import {
-  BrowserRouter,
-  Route,
-  Routes,
-  Navigate,
-  useNavigate,
-} from "react-router-dom";
+import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import New from "./pages/New";
 import Diary from "./pages/Diary";

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useReducer, useRef, useEffect } from "react";
+import React, { useReducer, useEffect, useState } from "react";
 import "./App.css";
 import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
@@ -22,16 +22,16 @@ export const DiaryDispatchContext = React.createContext();
 function App() {
   const [data, dispatch] = useReducer(diaryReducer, initialState);
   const { user, updateUser } = useAuth();
-  const dataId = useRef(0);
+  const [dataId, setDataId] = useState(0);
 
   useEffect(() => {
     if (user) {
-      onInitialize(dispatch, user);
+      onInitialize(dispatch, user, setDataId);
     }
   }, [user, dispatch]);
 
   const handleCreate = async (date, content, emotion) => {
-    await onCreate(dispatch, user, dataId, date, content, emotion);
+    await onCreate(dispatch, user, dataId, date, content, emotion, setDataId);
   };
 
   const handleRemove = async (targetId) => {

--- a/src/App.js
+++ b/src/App.js
@@ -6,8 +6,8 @@ import New from "./pages/New";
 import Diary from "./pages/Diary";
 import Edit from "./pages/Edit";
 import Login from "./pages/Login";
+import { useAuth } from "./hooks/useAuth";
 import { getDiaries } from "./firebase/diaryManager";
-
 import {
   diaryReducer,
   initialState,
@@ -22,15 +22,8 @@ export const DiaryDispatchContext = React.createContext();
 function App() {
   const [data, dispatch] = useReducer(diaryReducer, initialState);
   const [diaryList, setDiaryList] = useState([]);
-  const [user, setUser] = useState("");
 
-  useEffect(() => {
-    const loginedUser = localStorage.getItem("kakao_email");
-
-    if (loginedUser) {
-      setUser(loginedUser);
-    }
-  }, []);
+  const { user, updateUser } = useAuth();
 
   const getDiaryList = async () => {
     const dataArray = await getDiaries(user);
@@ -76,12 +69,27 @@ function App() {
         <BrowserRouter>
           <div className="App">
             <Routes>
-              <Route path="/" element={<Navigate replace to="/login" />} />
-              <Route path="/home" element={<Home />} />
-              <Route path="/login" element={<Login setUser={setUser} />} />
-              <Route path="/new" element={<New />} />
-              <Route path="/diary/:diaryId" element={<Diary />} />
-              <Route path="/edit/:diaryId" element={<Edit />} />
+              <Route
+                path="/"
+                element={<Navigate replace to={user ? "/home" : "/login"} />}
+              />
+              <Route
+                path="/home"
+                element={user ? <Home /> : <Navigate replace to="/login" />}
+              />
+              <Route path="/login" element={<Login setUser={updateUser} />} />
+              <Route
+                path="/new"
+                element={user ? <New /> : <Navigate replace to="/login" />}
+              />
+              <Route
+                path="/diary/:diaryId"
+                element={user ? <Diary /> : <Navigate replace to="/login" />}
+              />
+              <Route
+                path="/edit/:diaryId"
+                element={user ? <Edit /> : <Navigate replace to="/login" />}
+              />
             </Routes>
           </div>
         </BrowserRouter>

--- a/src/components/DiaryEditor.js
+++ b/src/components/DiaryEditor.js
@@ -55,12 +55,14 @@ const DiaryEditor = ({ isEdit, originData }) => {
         handleDiaryRemove();
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modalCheck, modalStatus]);
 
   const handleDiaryRemove = () => {
     if (modalCheck) {
-      handleRemove(originData.diaryId);
-      navigate("/home", { replace: true });
+      handleRemove(originData.diaryId, () => {
+        navigate("/home", { replace: true });
+      });
       setModalCheck(false);
     }
   };

--- a/src/components/DiaryEditor.js
+++ b/src/components/DiaryEditor.js
@@ -19,7 +19,8 @@ const DiaryEditor = ({ isEdit, originData }) => {
   const [modalStatus, setModalStatus] = useState("");
   const [modalCheck, setModalCheck] = useState(false);
 
-  const { onCreate, onEdit, onRemove } = useContext(DiaryDispatchContext);
+  const { handleCreate, handleEdit, handleRemove } =
+    useContext(DiaryDispatchContext);
   const handleClickEmote = useCallback((emotion) => {
     setEmotion(emotion);
   }, []);
@@ -36,10 +37,10 @@ const DiaryEditor = ({ isEdit, originData }) => {
 
     if (modalCheck) {
       if (!isEdit) {
-        onCreate(date, content, emotion);
+        handleCreate(date, content, emotion);
         setModalCheck(false);
       } else {
-        onEdit(originData.diaryId, date, content, emotion);
+        handleEdit(originData.diaryId, date, content, emotion);
         setModalCheck(false);
       }
     }
@@ -51,14 +52,14 @@ const DiaryEditor = ({ isEdit, originData }) => {
       if (modalStatus === "수정" || modalStatus === "작성") {
         handleSubmit();
       } else if (modalStatus === "삭제") {
-        handleRemove();
+        handleDiaryRemove();
       }
     }
   }, [modalCheck, modalStatus]);
 
-  const handleRemove = () => {
+  const handleDiaryRemove = () => {
     if (modalCheck) {
-      onRemove(originData.diaryId);
+      handleRemove(originData.diaryId);
       navigate("/home", { replace: true });
       setModalCheck(false);
     }
@@ -89,7 +90,6 @@ const DiaryEditor = ({ isEdit, originData }) => {
                 text={"삭제하기"}
                 type={"negative"}
                 onClick={() => {
-                  // handleRemove();
                   setModalStatus("삭제");
                   setOpenModal(true);
                 }}

--- a/src/firebase/diaryManager.js
+++ b/src/firebase/diaryManager.js
@@ -1,0 +1,41 @@
+import { db } from "./firebaseConfig";
+import {
+  collection,
+  getDocs,
+  addDoc,
+  updateDoc,
+  doc,
+  deleteDoc,
+  query,
+  where,
+} from "firebase/firestore";
+
+const diaryCollectionRef = collection(db, "diary");
+
+export const getDiaries = async (user) => {
+  const diaryData = await getDocs(
+    query(diaryCollectionRef, where("user", "==", user))
+  );
+  return diaryData.docs.map((doc) => ({
+    id: doc.id,
+    diaryId: doc.diaryId,
+    user: doc.user,
+    ...doc.data(),
+  }));
+};
+
+export const createDiary = async (data) => {
+  await addDoc(diaryCollectionRef, {
+    ...data,
+    user: localStorage.getItem("kakao_email"),
+  });
+};
+
+export const updateDiary = async (id, data) => {
+  const docRef = doc(diaryCollectionRef, id);
+  await updateDoc(docRef, data);
+};
+
+export const deleteDiary = async (id) => {
+  await deleteDoc(doc(db, "diary", id));
+};

--- a/src/firebase/diaryManager.js
+++ b/src/firebase/diaryManager.js
@@ -31,9 +31,9 @@ export const createDiary = async (data) => {
   });
 };
 
-export const updateDiary = async (id, data) => {
+export const updateDiary = async (id, updatedData) => {
   const docRef = doc(diaryCollectionRef, id);
-  await updateDoc(docRef, data);
+  await updateDoc(docRef, updatedData);
 };
 
 export const deleteDiary = async (id) => {

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,17 @@
+import { useState, useEffect, useCallback } from "react";
+
+export const useAuth = () => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const loginedUser = localStorage.getItem("kakao_email");
+    setUser(loginedUser);
+  }, []);
+
+  const updateUser = useCallback((email) => {
+    localStorage.setItem("kakao_email", email);
+    setUser(email);
+  }, []);
+
+  return { user, updateUser };
+};

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -9,7 +9,11 @@ export const useAuth = () => {
   }, []);
 
   const updateUser = useCallback((email) => {
-    localStorage.setItem("kakao_email", email);
+    if (email) {
+      localStorage.setItem("kakao_email", email);
+    } else {
+      localStorage.removeItem("kakao_email");
+    }
     setUser(email);
   }, []);
 

--- a/src/hooks/useLogout.js
+++ b/src/hooks/useLogout.js
@@ -1,0 +1,15 @@
+import { useAuth } from "./useAuth";
+
+export const useLogout = () => {
+  const { updateUser } = useAuth();
+
+  const onLogout = () => {
+    try {
+      updateUser(null);
+    } catch (error) {
+      console.error("로그아웃 중 에러 발생:", error);
+      alert("로그아웃에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+  return { onLogout };
+};

--- a/src/pages/Diary.js
+++ b/src/pages/Diary.js
@@ -15,7 +15,7 @@ const Diary = () => {
   useEffect(() => {
     const titleElement = document.getElementsByTagName("title")[0];
     titleElement.innerHTML = `감정 일기장 - ${diaryId}번 일기`;
-  }, []);
+  }, [diaryId]);
 
   useEffect(() => {
     if (diaryList.length >= 1) {
@@ -26,7 +26,6 @@ const Diary = () => {
       if (targetDiary) {
         setData(targetDiary);
       } else {
-        alert("없는 일기입니다.");
         navigate("/home", { replace: true });
       }
     }

--- a/src/pages/Diary.js
+++ b/src/pages/Diary.js
@@ -29,7 +29,7 @@ const Diary = () => {
         navigate("/home", { replace: true });
       }
     }
-  }, [diaryId, diaryList]);
+  }, [diaryId, diaryList, navigate]);
 
   if (!data) {
     return <div>로딩중입니다...</div>;

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -12,7 +12,7 @@ const Edit = () => {
   useEffect(() => {
     const titleElement = document.getElementsByTagName("title")[0];
     titleElement.innerHTML = `감정 일기장 - ${diaryId}번 일기 수정`;
-  }, []);
+  }, [diaryId]);
 
   useEffect(() => {
     if (diaryList.length >= 1) {
@@ -26,7 +26,7 @@ const Edit = () => {
         navigate("/home", { replace: true });
       }
     }
-  }, [diaryId, diaryList]);
+  }, [diaryId, diaryList, navigate]);
 
   return (
     <div>

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -23,7 +23,6 @@ const Edit = () => {
       if (targetDiary) {
         setOrigindata(targetDiary);
       } else {
-        alert("없는 일기입니다.");
         navigate("/home", { replace: true });
       }
     }

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -6,6 +6,7 @@ import MyButton from "./../components/MyButton";
 import DiaryList from "../components/DiaryList";
 import { useAuth } from "../hooks/useAuth";
 import { useNavigate } from "react-router-dom";
+import { decreaseMonth, increaseMonth } from "../utils/date";
 const Home = () => {
   const diaryList = useContext(DiaryStateContext);
   const [data, setData] = useState([]);
@@ -55,24 +56,20 @@ const Home = () => {
     }
   }, [diaryList, curDate]);
 
-  const increaseMonth = () => {
-    setCurdate(
-      new Date(curDate.getFullYear(), curDate.getMonth() + 1, curDate.getDate())
-    );
+  const handleIncreaseMonth = () => {
+    setCurdate(increaseMonth(curDate));
   };
 
-  const decreaseMonth = () => {
-    setCurdate(
-      new Date(curDate.getFullYear(), curDate.getMonth() - 1, curDate.getDate())
-    );
+  const handleDecreaseMonth = () => {
+    setCurdate(decreaseMonth(curDate));
   };
 
   return (
     <div>
       <MyHeader
         headText={headText}
-        leftChild={<MyButton text={"<"} onClick={decreaseMonth} />}
-        rightChild={<MyButton text={">"} onClick={increaseMonth} />}
+        leftChild={<MyButton text={"<"} onClick={handleDecreaseMonth} />}
+        rightChild={<MyButton text={">"} onClick={handleIncreaseMonth} />}
       />
       <DiaryList diaryList={data} />
       <footer className="myfooter">

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -4,31 +4,28 @@ import { DiaryStateContext } from "./../App";
 import MyHeader from "./../components/MyHeader";
 import MyButton from "./../components/MyButton";
 import DiaryList from "../components/DiaryList";
+import { useAuth } from "../hooks/useAuth";
 import { useNavigate } from "react-router-dom";
-
 const Home = () => {
   const diaryList = useContext(DiaryStateContext);
   const [data, setData] = useState([]);
   const [curDate, setCurdate] = useState(new Date());
   const headText = `${curDate.getFullYear()}년 ${curDate.getMonth() + 1}월`;
+  const { user, updateUser } = useAuth();
+
   const navigate = useNavigate();
-  const [loginedUser, setLoginedUser] = useState(
-    localStorage.getItem("kakao_email")
-  );
-  const loginedUserName =
-    localStorage.getItem("kakao_email") === "test"
-      ? "비회원"
-      : localStorage.getItem("kakao_name");
 
   const handleLogout = () => {
-    localStorage.removeItem("kakao_email");
-    localStorage.removeItem("kakao_name");
-    setLoginedUser("");
+    try {
+      updateUser(null);
+      navigate("/login");
+    } catch (error) {
+      console.error("로그아웃 중 에러 발생:", error);
+      alert("로그아웃에 실패했습니다. 다시 시도해주세요.");
+    }
   };
-
-  useEffect(() => {
-    if (!loginedUser) navigate("/login");
-  }, [loginedUser]);
+  const loginedUserName =
+    user === "test" ? "비회원" : localStorage.getItem("kakao_name");
 
   useEffect(() => {
     const titleElement = document.getElementsByTagName("title")[0];
@@ -56,7 +53,7 @@ const Home = () => {
         diaryList.filter((it) => firstDay <= it.date && it.date <= lastDay)
       );
     }
-  }, [diaryList, curDate, loginedUser]);
+  }, [diaryList, curDate]);
 
   const increaseMonth = () => {
     setCurdate(

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,20 +1,23 @@
 import { useContext, useEffect, useState } from "react";
 import { DiaryStateContext } from "./../App";
-
 import MyHeader from "./../components/MyHeader";
 import MyButton from "./../components/MyButton";
 import DiaryList from "../components/DiaryList";
 import { useAuth } from "../hooks/useAuth";
 import { useNavigate } from "react-router-dom";
-import { decreaseMonth, increaseMonth } from "../utils/date";
+import {
+  decreaseMonth,
+  filterDiariesByMonth,
+  increaseMonth,
+} from "../utils/date";
+
 const Home = () => {
   const diaryList = useContext(DiaryStateContext);
   const [data, setData] = useState([]);
   const [curDate, setCurdate] = useState(new Date());
-  const headText = `${curDate.getFullYear()}년 ${curDate.getMonth() + 1}월`;
   const { user, updateUser } = useAuth();
-
   const navigate = useNavigate();
+  const headText = `${curDate.getFullYear()}년 ${curDate.getMonth() + 1}월`;
 
   const handleLogout = () => {
     try {
@@ -35,24 +38,7 @@ const Home = () => {
 
   useEffect(() => {
     if (diaryList.length >= 1) {
-      const firstDay = new Date(
-        curDate.getFullYear(),
-        curDate.getMonth(),
-        1
-      ).getTime();
-
-      const lastDay = new Date(
-        curDate.getFullYear(),
-        curDate.getMonth() + 1,
-        0,
-        23,
-        59,
-        59
-      ).getTime();
-
-      setData(
-        diaryList.filter((it) => firstDay <= it.date && it.date <= lastDay)
-      );
+      setData(filterDiariesByMonth(diaryList, curDate));
     }
   }, [diaryList, curDate]);
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -10,24 +10,17 @@ import {
   filterDiariesByMonth,
   increaseMonth,
 } from "../utils/date";
+import { useLogout } from "../hooks/useLogout";
 
 const Home = () => {
   const diaryList = useContext(DiaryStateContext);
   const [data, setData] = useState([]);
   const [curDate, setCurdate] = useState(new Date());
-  const { user, updateUser } = useAuth();
+  const { user } = useAuth();
+  const { onLogout } = useLogout();
   const navigate = useNavigate();
   const headText = `${curDate.getFullYear()}년 ${curDate.getMonth() + 1}월`;
 
-  const handleLogout = () => {
-    try {
-      updateUser(null);
-      navigate("/login");
-    } catch (error) {
-      console.error("로그아웃 중 에러 발생:", error);
-      alert("로그아웃에 실패했습니다. 다시 시도해주세요.");
-    }
-  };
   const loginedUserName =
     user === "test" ? "비회원" : localStorage.getItem("kakao_name");
 
@@ -41,6 +34,11 @@ const Home = () => {
       setData(filterDiariesByMonth(diaryList, curDate));
     }
   }, [diaryList, curDate]);
+
+  const handleLogout = () => {
+    onLogout();
+    navigate("/login");
+  };
 
   const handleIncreaseMonth = () => {
     setCurdate(increaseMonth(curDate));

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -5,6 +5,11 @@ function Login({ setUser }) {
   const navigate = useNavigate();
   const kakaoJs = process.env.REACT_APP_KAKAO_JS;
 
+  useEffect(() => {
+    localStorage.removeItem("kakao_email");
+    localStorage.removeItem("kakao_name");
+  }, []);
+
   // 카카오 로그인
   useEffect(() => {
     const script = document.createElement("script");

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -53,7 +53,7 @@ function Login({ setUser }) {
         }
       };
     };
-  }, []);
+  }, [kakaoJs, navigate, setUser]);
 
   const handleTestLogin = () => {
     setUser("test");

--- a/src/reducer/diaryReducer.js
+++ b/src/reducer/diaryReducer.js
@@ -1,3 +1,5 @@
+import { sortDiaryList } from "./../utils/sortDiaries";
+import { getDiaries } from "../firebase/diaryManager";
 import {
   createDiary,
   deleteDiary,
@@ -32,11 +34,19 @@ export const diaryReducer = (state, action) => {
 
 export const initialState = [];
 
+//INIT
+export const onInitialize = async (dispatch, user) => {
+  const sortedDiaries = await sortDiaryList(user);
+  if (sortDiaryList.length > 0) {
+    dispatch({ type: "INIT", data: sortedDiaries });
+  }
+};
+
 // CREATE
 export const onCreate = async (
   dispatch,
+  user,
   dataId,
-  getDiaryList,
   date,
   content,
   emotion
@@ -53,14 +63,14 @@ export const onCreate = async (
     dispatch({ type: "CREATE", data: newData });
     dataId.current += 1;
 
-    getDiaryList();
+    await getDiaries(user);
   } catch (error) {
     console.error(error);
   }
 };
 
 // REMOVE
-export const onRemove = async (dispatch, data, getDiaryList, targetId) => {
+export const onRemove = async (dispatch, user, data, targetId) => {
   try {
     const targetData = data.find((item) => item.diaryId === targetId);
     if (!targetData) {
@@ -71,7 +81,7 @@ export const onRemove = async (dispatch, data, getDiaryList, targetId) => {
     await deleteDiary(targetData.id);
 
     dispatch({ type: "REMOVE", targetId });
-    getDiaryList();
+    getDiaries(user);
   } catch (error) {
     console.error(error);
   }

--- a/src/reducer/diaryReducer.js
+++ b/src/reducer/diaryReducer.js
@@ -1,0 +1,111 @@
+import {
+  createDiary,
+  deleteDiary,
+  updateDiary,
+} from "../firebase/diaryManager";
+
+export const diaryReducer = (state, action) => {
+  let newState = [];
+  switch (action.type) {
+    case "INIT": {
+      return action.data;
+    }
+    case "CREATE": {
+      newState = [action.data, ...state];
+      break;
+    }
+    case "REMOVE": {
+      newState = state.filter((it) => it.diaryId !== action.targetId);
+      break;
+    }
+    case "EDIT": {
+      newState = state.map((it) =>
+        it.diaryId === action.data.diaryId ? { ...action.data } : it
+      );
+      break;
+    }
+    default:
+      return state;
+  }
+  return newState;
+};
+
+export const initialState = [];
+
+// CREATE
+export const onCreate = async (
+  dispatch,
+  dataId,
+  getDiaryList,
+  date,
+  content,
+  emotion
+) => {
+  try {
+    const newData = {
+      diaryId: dataId.current,
+      emotion,
+      content,
+      date: new Date(date).getTime(),
+    };
+
+    await createDiary(newData);
+    dispatch({ type: "CREATE", data: newData });
+    dataId.current += 1;
+
+    getDiaryList();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// REMOVE
+export const onRemove = async (dispatch, data, getDiaryList, targetId) => {
+  try {
+    const targetData = data.find((item) => item.diaryId === targetId);
+    if (!targetData) {
+      console.error("해당 데이터를 찾을 수 없습니다.");
+      return;
+    }
+
+    await deleteDiary(targetData.id);
+
+    dispatch({ type: "REMOVE", targetId });
+    getDiaryList();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// EDIT
+export const onEdit = async (
+  dispatch,
+  data,
+  targetId,
+  date,
+  content,
+  emotion
+) => {
+  try {
+    const targetData = data.find((item) => item.diaryId === targetId);
+
+    if (!targetData) {
+      console.error("해당 데이터를 찾을 수 없습니다.");
+      return;
+    }
+
+    const updatedData = {
+      emotion,
+      content,
+      date: new Date(date).getTime(),
+    };
+    await updateDiary(targetData.id, updatedData);
+
+    dispatch({
+      type: "EDIT",
+      data: { ...updatedData, diaryId: targetId, id: targetData.id },
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/reducer/diaryReducer.js
+++ b/src/reducer/diaryReducer.js
@@ -35,9 +35,10 @@ export const diaryReducer = (state, action) => {
 export const initialState = [];
 
 //INIT
-export const onInitialize = async (dispatch, user) => {
+export const onInitialize = async (dispatch, user, setDataId) => {
   const sortedDiaries = await sortDiaryList(user);
   if (sortDiaryList.length > 0) {
+    setDataId(sortedDiaries.length);
     dispatch({ type: "INIT", data: sortedDiaries });
   }
 };
@@ -49,11 +50,12 @@ export const onCreate = async (
   dataId,
   date,
   content,
-  emotion
+  emotion,
+  setDataId
 ) => {
   try {
     const newData = {
-      diaryId: dataId.current,
+      diaryId: dataId,
       emotion,
       content,
       date: new Date(date).getTime(),
@@ -61,8 +63,7 @@ export const onCreate = async (
 
     await createDiary(newData);
     dispatch({ type: "CREATE", data: newData });
-    dataId.current += 1;
-
+    setDataId(dataId + 1);
     await getDiaries(user);
   } catch (error) {
     console.error(error);

--- a/src/reducer/diaryReducer.js
+++ b/src/reducer/diaryReducer.js
@@ -108,6 +108,7 @@ export const onEdit = async (
     const updatedData = {
       emotion,
       content,
+      user,
       date: new Date(date).getTime(),
     };
     await updateDiary(targetData.id, updatedData);

--- a/src/reducer/diaryReducer.js
+++ b/src/reducer/diaryReducer.js
@@ -1,5 +1,4 @@
 import { sortDiaryList } from "./../utils/sortDiaries";
-import { getDiaries } from "../firebase/diaryManager";
 import {
   createDiary,
   deleteDiary,

--- a/src/reducer/diaryReducer.js
+++ b/src/reducer/diaryReducer.js
@@ -35,10 +35,9 @@ export const diaryReducer = (state, action) => {
 export const initialState = [];
 
 //INIT
-export const onInitialize = async (dispatch, user, setDataId) => {
+export const onInitialize = async (dispatch, user) => {
   const sortedDiaries = await sortDiaryList(user);
   if (sortDiaryList.length > 0) {
-    setDataId(sortedDiaries.length);
     dispatch({ type: "INIT", data: sortedDiaries });
   }
 };
@@ -50,21 +49,19 @@ export const onCreate = async (
   dataId,
   date,
   content,
-  emotion,
-  setDataId
+  emotion
 ) => {
   try {
     const newData = {
       diaryId: dataId,
       emotion,
       content,
+      user,
       date: new Date(date).getTime(),
     };
 
     await createDiary(newData);
     dispatch({ type: "CREATE", data: newData });
-    setDataId(dataId + 1);
-    await getDiaries(user);
   } catch (error) {
     console.error(error);
   }
@@ -73,16 +70,16 @@ export const onCreate = async (
 // REMOVE
 export const onRemove = async (dispatch, user, data, targetId) => {
   try {
-    const targetData = data.find((item) => item.diaryId === targetId);
+    const targetData = data.find(
+      (item) => item.diaryId === targetId && item.user === user
+    );
     if (!targetData) {
       console.error("해당 데이터를 찾을 수 없습니다.");
       return;
     }
 
     await deleteDiary(targetData.id);
-
     dispatch({ type: "REMOVE", targetId });
-    getDiaries(user);
   } catch (error) {
     console.error(error);
   }
@@ -95,10 +92,13 @@ export const onEdit = async (
   targetId,
   date,
   content,
-  emotion
+  emotion,
+  user
 ) => {
   try {
-    const targetData = data.find((item) => item.diaryId === targetId);
+    const targetData = data.find(
+      (item) => item.diaryId === targetId && item.user === user
+    );
 
     if (!targetData) {
       console.error("해당 데이터를 찾을 수 없습니다.");

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -15,3 +15,19 @@ export const getStringDate = (date) => {
 
   return `${year}-${month}-${day}`;
 };
+
+export const increaseMonth = (currentDate) => {
+  return new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth() + 1,
+    currentDate.getDate()
+  );
+};
+
+export const decreaseMonth = (currentDate) => {
+  return new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth() - 1,
+    currentDate.getDate()
+  );
+};

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -31,3 +31,23 @@ export const decreaseMonth = (currentDate) => {
     currentDate.getDate()
   );
 };
+
+export const filterDiariesByMonth = (diaryList, curDate) => {
+  const firstDay = new Date(
+    curDate.getFullYear(),
+    curDate.getMonth(),
+    1
+  ).getTime();
+  const lastDay = new Date(
+    curDate.getFullYear(),
+    curDate.getMonth() + 1,
+    0,
+    23,
+    59,
+    59
+  ).getTime();
+
+  return diaryList.filter(
+    (diary) => firstDay <= diary.date && diary.date <= lastDay
+  );
+};

--- a/src/utils/sortDiaries.js
+++ b/src/utils/sortDiaries.js
@@ -1,0 +1,6 @@
+import { getDiaries } from "../firebase/diaryManager";
+
+export const sortDiaryList = async (user) => {
+  const diaryData = await getDiaries(user);
+  return diaryData.sort((a, b) => parseInt(b.diaryId) - parseInt(a.diaryId));
+};


### PR DESCRIPTION
**리팩토링 목적**
컴포넌트 안에 무분별하게 섞여있는 비즈니스 로직을 분리하고, 커스텀 훅을 생성 및 반영하여 코드 가독성과 유지 보수성 향상을 목표로 함.


**구현한 기능**

*App.js 안에 있는 비즈니스 로직 분리*

- 파이어베이스 코드 분리
- reducer dispatch 함수 코드 분리
- 로그인 관련 처리하는 커스텀 훅 생성 및 적용
- App.js 안에 있는 INIT 액션 처리 코드(일기 데이터 불러오고, id 내림차순으로 정렬) 분리

*Home 페이지 비즈니스 로직 분리*
- useAuth() 적용
- 현재 날짜를 기반으로 다음 달 또는 이전 달로 이동하는 함수 분리 (increaseMonth, decreaseMonth)
- 월별 일기 데이터 필터링 로직 분리
- 로그아웃 처리하는 커스텀 훅 생성 및 적용

*BugFix*

- 문제 상황 및 원인
로그아웃을 하고 다른 유저로 로그인을 했을 때, 이전 로그인 유저의 일기 데이터가 초기 화면에 렌더링됨. 새로고침을 하고나서야 새로운 로그인 유저의 일기 데이터가 렌더링됨. 로그아웃 시 로컬 스토리지에 저장된 로그인 유저 정보가 제거가 되지 않아서 새로 로그인을 하고나서 그 로그인 유저의 데이터를 렌더링하기 전에 이전 로그인 유저의 일기데이터가 초기 렌더링이 된 것임.

- 해결
로그인 페이지 접근 시 로컬스토리지의 로그인 유저 정보를 제거하도록 추가함.


**어려웠던 점**
context API와 firebase를 같이 쓰고 있는데 코드 중복을 줄이는 것과과 성능 개선의 사이에서 고민이 많았다. 전역 상태와 DB와 연동된 데이터의 관리 및 구조 설계에 대해 가장 시간을 많이 썼다. 코드 중복이 있는 부분은 코드 분리를 통해 최대한 가독성을 높였고 대신 파이어베이스와 통신하는 코드는 최소한으로 줄였다. 커스텀 훅을 만드는 것에 익숙하지 않아서 기존 코드와 커스텀 훅을 만들었을 때의 장단점을 비교하는 것이 어려웠다. 두 방식을 직접 테스트 해보며 전체적인 코드 가독성을 중점으로 리팩토링 작업을 하였다.