### PR TITLE
[#1][Refactor] 비즈니스 로직 분리 및 커스텀 훅 생성

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -5,7 +5,7 @@ name: Deploy to Firebase Hosting on merge
 'on':
   push:
     branches:
-      - develop
+      - main
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,11 @@
   "hosting": {
     "site": "eeeyooon-emotion-diary",
     "public": "build",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "rewrites": [
       {
         "source": "**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,11 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "firebase": "^10.4.0",
+        "firebase": "^10.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.13.0",
         "react-scripts": "5.0.1",
-        "styled-components": "^6.0.8",
-        "styled-reset": "^4.5.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -50,78 +48,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/cli": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.22.15.tgz",
-      "integrity": "sha512-prtg5f6zCERIaECeTZzd2fMtVjlfjhUcO+fBLQ6DXXdq5FljN+excVitJ2nogsusdf31LeqkjAfXZ7Xq+HmN8g==",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "commander": "^4.0.1",
-        "convert-source-map": "^1.1.0",
-        "fs-readdir-recursive": "^1.1.0",
-        "glob": "^7.2.0",
-        "make-dir": "^2.1.0",
-        "slash": "^2.0.0"
-      },
-      "bin": {
-        "babel": "bin/babel.js",
-        "babel-external-helpers": "bin/babel-external-helpers.js"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "optionalDependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-        "chokidar": "^3.4.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/cli/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@babel/cli/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/cli/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/cli/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@babel/cli/node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -614,20 +540,6 @@
         "@babel/core": "^7.13.0"
       }
     },
-    "node_modules/@babel/plugin-external-helpers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.22.5.tgz",
-      "integrity": "sha512-ngnNEWxmykPk82mH4ajZT0qTztr3Je6hrMuKAslZVM8G1YZTENJSYwrIGtt6KOtznug3exmAtF4so/nPqJuA4A==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
@@ -683,25 +595,6 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
-      "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2417,24 +2310,6 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.1"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2528,6 +2403,14 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@firebase/analytics": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.0.tgz",
@@ -2564,9 +2447,9 @@
       "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.19.tgz",
-      "integrity": "sha512-t/SHyZ3xWkR77ZU9VMoobDNFLdDKQ5xqoCAn4o16gTsA1C8sJ6ZOMZ02neMOPxNHuQXVE4tA8ukilnDbnK7uJA==",
+      "version": "0.9.25",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.25.tgz",
+      "integrity": "sha512-fX22gL5USXhOK21Hlh3oTeOzQZ6th6S2JrjXNEpBARmwzuUkqmVGVdsOCIFYIsLpK0dQE3o8xZnLrRg5wnzZ/g==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -2576,9 +2459,9 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.0.tgz",
-      "integrity": "sha512-dRDnhkcaC2FspMiRK/Vbp+PfsOAEP6ZElGm9iGFJ9fDqHoPs0HOPn7dwpJ51lCFi1+2/7n5pRPGhqF/F03I97g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.1.tgz",
+      "integrity": "sha512-zi3vbM5tb/eGRWyiqf+1DXbxFu9Q07dnm46rweodgUpH9B8svxYkHfNwYWx7F5mjHU70SQDuaojH1We5ws9OKA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -2590,11 +2473,11 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.7.tgz",
-      "integrity": "sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.8.tgz",
+      "integrity": "sha512-EaETtChR4UgMokJFw+r6jfcIyCTUZSe0a6ivF37D9MxlG9G3wzK1COyXgxoX96GzXmDPc2aubX4PxCrdVHhrnA==",
       "dependencies": {
-        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check": "0.8.1",
         "@firebase/app-check-types": "0.5.0",
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -2616,11 +2499,11 @@
       "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.19.tgz",
-      "integrity": "sha512-QkJDqYqjhvs4fTMcRVXQkP9hbo5yfoJXDWkhU4VA5Vzs8Qsp76VPzYbqx5SD5OmBy+bz/Ot1UV8qySPGI4aKuw==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.25.tgz",
+      "integrity": "sha512-B/JtCp1FsTuzlh1tIGQpYM2AXps21/zlzpFsk5LRsROOTRhBcR2N45AyaONPFD06C0yS0Tw19foxADzHyOSC3A==",
       "dependencies": {
-        "@firebase/app": "0.9.19",
+        "@firebase/app": "0.9.25",
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
@@ -2633,15 +2516,15 @@
       "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
     },
     "node_modules/@firebase/auth": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.3.0.tgz",
-      "integrity": "sha512-vjK4CHbY9aWdiVOrKi6mpa8z6uxeaf7LB/MZTHuZOiGHMcUoTGB6TeMbRShyqk1uaMrxhhZ5Ar/dR0965E1qyA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.5.1.tgz",
+      "integrity": "sha512-sVi7rq2YneLGJFqHa5S6nDfCHix9yuVV3RLhj/pWPlB4a36ofXal4E6PJwpeMc8uLjWEr1aovYN1jkXWNB6Avw==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "undici": "5.26.5"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -2654,16 +2537,16 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.4.6.tgz",
-      "integrity": "sha512-pKp1d4fSf+yoy1EBjTx9ISxlunqhW0vTICk0ByZ3e+Lp6ZIXThfUy4F1hAJlEafD/arM0oepRiAh7LXS1xn/BA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.1.tgz",
+      "integrity": "sha512-rgDZnrDoekRvtzXVji8Z61wxxkof6pTkjYEkybILrjM8tGP9tx4xa9qGpF4ax3AzF+rKr7mIa9NnoXEK4UNqmQ==",
       "dependencies": {
-        "@firebase/auth": "1.3.0",
+        "@firebase/auth": "1.5.1",
         "@firebase/auth-types": "0.12.0",
         "@firebase/component": "0.6.4",
         "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "undici": "5.26.5"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -2693,10 +2576,11 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.1.tgz",
-      "integrity": "sha512-VAhF7gYwunW4Lw/+RQZvW8dlsf2r0YYqV9W0Gi2Mz8+0TGg1mBJWoUtsHfOr8kPJXhcLsC4eP/z3x6L/Fvjk/A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.2.tgz",
+      "integrity": "sha512-8X6NBJgUQzDz0xQVaCISoOLINKat594N2eBbMR3Mu/MH/ei4WM+aAMlsNzngF22eljXu1SILP5G3evkyvsG3Ng==",
       "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.0",
         "@firebase/auth-interop-types": "0.2.1",
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -2706,12 +2590,12 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.1.tgz",
-      "integrity": "sha512-ky82yLIboLxtAIWyW/52a6HLMVTzD2kpZlEilVDok73pNPLjkJYowj8iaIWK5nTy7+6Gxt7d00zfjL6zckGdXQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.2.tgz",
+      "integrity": "sha512-09ryJnXDvuycsxn8aXBzLhBTuCos3HEnCOBWY6hosxfYlNCGnLvG8YMlbSAt5eNhf7/00B095AEfDsdrrLjxqA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
-        "@firebase/database": "1.0.1",
+        "@firebase/database": "1.0.2",
         "@firebase/database-types": "1.0.0",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
@@ -2728,18 +2612,18 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.2.0.tgz",
-      "integrity": "sha512-iKZqIdOBJpJUcwY5airLX0W04TLrQSJuActOP1HG5WoIY5oyGTQE4Ml7hl5GW7mBqFieT4ojtUuDXj6MLrn1lA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.4.0.tgz",
+      "integrity": "sha512-VeDXD9PUjvcWY1tInBOMTIu2pijR3YYy+QAe5cxCo1Q1vW+aA/mpQHhebPM1J6b4Zd1MuUh8xpBRvH9ujKR56A==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
-        "@firebase/webchannel-wrapper": "0.10.3",
+        "@firebase/webchannel-wrapper": "0.10.5",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
-        "node-fetch": "2.6.7",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "undici": "5.26.5"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -2749,12 +2633,12 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.18.tgz",
-      "integrity": "sha512-hkqv4mb1oScKbEtzfcK8Go8c0VpDWmbAvbD6B6XnphLqi27pkXgo9Rp+aSKlD7cBL29VMEekP5bEm9lSVfZpNw==",
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.23.tgz",
+      "integrity": "sha512-uUTBiP0GLVBETaOCfB11d33OWB8x1r2G1Xrl0sRK3Va0N5LJ/GRvKVSGfM7VScj+ypeHe8RpdwKoCqLpN1e+uA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
-        "@firebase/firestore": "4.2.0",
+        "@firebase/firestore": "4.4.0",
         "@firebase/firestore-types": "3.0.0",
         "@firebase/util": "1.9.3",
         "tslib": "^2.1.0"
@@ -2773,29 +2657,29 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.10.0.tgz",
-      "integrity": "sha512-2U+fMNxTYhtwSpkkR6WbBcuNMOVaI7MaH3cZ6UAeNfj7AgEwHwMIFLPpC13YNZhno219F0lfxzTAA0N62ndWzA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.0.tgz",
+      "integrity": "sha512-n1PZxKnJ++k73Q8khTPwihlbeKo6emnGzE0hX6QVQJsMq82y/XKmNpw2t/q30VJgwaia3ZXU1fd1C5wHncL+Zg==",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.0",
         "@firebase/auth-interop-types": "0.2.1",
         "@firebase/component": "0.6.4",
         "@firebase/messaging-interop-types": "0.2.0",
         "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "undici": "5.26.5"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.5.tgz",
-      "integrity": "sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.6.tgz",
+      "integrity": "sha512-RQpO3yuHtnkqLqExuAT2d0u3zh8SDbeBYK5EwSCBKI9mjrFeJRXBnd3pEG+x5SxGJLy56/5pQf73mwt0OuH5yg==",
       "dependencies": {
         "@firebase/component": "0.6.4",
-        "@firebase/functions": "0.10.0",
+        "@firebase/functions": "0.11.0",
         "@firebase/functions-types": "0.6.0",
         "@firebase/util": "1.9.3",
         "tslib": "^2.1.0"
@@ -2860,15 +2744,15 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.4.tgz",
-      "integrity": "sha512-6JLZct6zUaex4g7HI3QbzeUrg9xcnmDAPTWpkoMpd/GoSVWH98zDoWXMGrcvHeCAIsLpFMe4MPoZkJbrPhaASw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.5.tgz",
+      "integrity": "sha512-i/rrEI2k9ueFhdIr8KQsptWGskrsnkC5TkohCTrJKz9P0C/PbNv14IAMkwhMJTqIur5VwuOnrUkc9Kdz7awekw==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/installations": "0.6.4",
         "@firebase/messaging-interop-types": "0.2.0",
         "@firebase/util": "1.9.3",
-        "idb": "7.0.1",
+        "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2876,12 +2760,12 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.4.tgz",
-      "integrity": "sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.5.tgz",
+      "integrity": "sha512-qHQZxm4hEG8/HFU/ls5/bU+rpnlPDoZoqi3ATMeb6s4hovYV9+PfV5I7ZrKV5eFFv47Hx1PWLe5uPnS4e7gMwQ==",
       "dependencies": {
         "@firebase/component": "0.6.4",
-        "@firebase/messaging": "0.12.4",
+        "@firebase/messaging": "0.12.5",
         "@firebase/util": "1.9.3",
         "tslib": "^2.1.0"
       },
@@ -2893,11 +2777,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.0.tgz",
       "integrity": "sha512-ujA8dcRuVeBixGR9CtegfpU4YmZf3Lt7QYkcj693FFannwNuZgfAYaTmbJ40dtjB81SAu6tbFPL9YLNT15KmOQ=="
-    },
-    "node_modules/@firebase/messaging/node_modules/idb": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
-      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
     },
     "node_modules/@firebase/performance": {
       "version": "0.6.4",
@@ -2972,26 +2851,26 @@
       "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA=="
     },
     "node_modules/@firebase/storage": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.11.2.tgz",
-      "integrity": "sha512-CtvoFaBI4hGXlXbaCHf8humajkbXhs39Nbh6MbNxtwJiCqxPy9iH3D3CCfXAvP0QvAAwmJUTK3+z9a++Kc4nkA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.12.0.tgz",
+      "integrity": "sha512-SGs02Y/mmWBRsqZiYLpv4Sf7uZYZzMWVNN+aKiDqPsFBCzD6hLvGkXz+u98KAl8FqcjgB8BtSu01wm4pm76KHA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "undici": "5.26.5"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.2.tgz",
-      "integrity": "sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.3.tgz",
+      "integrity": "sha512-WNtjYPhpOA1nKcRu5lIodX0wZtP8pI0VxDJnk6lr+av7QZNS1s6zvr+ERDTve+Qu4Hq/ZnNaf3kBEQR2ccXn6A==",
       "dependencies": {
         "@firebase/component": "0.6.4",
-        "@firebase/storage": "0.11.2",
+        "@firebase/storage": "0.12.0",
         "@firebase/storage-types": "0.8.0",
         "@firebase/util": "1.9.3",
         "tslib": "^2.1.0"
@@ -3018,14 +2897,14 @@
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.3.tgz",
-      "integrity": "sha512-+ZplYUN3HOpgCfgInqgdDAbkGGVzES1cs32JJpeqoh87SkRobGXElJx+1GZSaDqzFL+bYiX18qEcBK76mYs8uA=="
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.5.tgz",
+      "integrity": "sha512-eSkJsnhBWv5kCTSU1tSUVl9mpFu+5NXXunZc83le8GMjMlsWwQArSc7cJJ4yl+aDFY0NGLi0AjZWMn1axOrkRg=="
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.3.tgz",
-      "integrity": "sha512-b8iWtdrYIeT5fdZdS4Br/6h/kuk0PW5EVBUGk1amSbrpL8DlktJD43CdcCWwRdd6+jgwHhADSbL9CsNnm6EUPA==",
+      "version": "1.9.13",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
+      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -3035,9 +2914,9 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.9.tgz",
-      "integrity": "sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -3862,12 +3741,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
-    },
-    "node_modules/@nicolo-ribaudo/chokidar-2": {
-      "version": "2.1.8-no-fsevents.3",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
-      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
-      "optional": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -5204,11 +5077,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
-    },
-    "node_modules/@types/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw=="
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.6",
@@ -6573,14 +6441,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -7016,14 +6876,6 @@
         "postcss": "^8.4"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
@@ -7204,16 +7056,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
-      }
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -9070,35 +8912,35 @@
       }
     },
     "node_modules/firebase": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.4.0.tgz",
-      "integrity": "sha512-3Z8WsNwA7kbcKGZ+nrTZ/ES518pk0K440ZJYD8nUNKN5hV6ll+unhUw30t1msedN6yIFjhsC/9OwT4Z0ohwO2w==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.7.1.tgz",
+      "integrity": "sha512-Mlt7y7zQ43FtKp4SCyYie3tnrOL3UMF2XXiV4ZXMrC0d0wtcOYmABuybhkJpJCKILpdekxr39wjnaai0DZlWFg==",
       "dependencies": {
         "@firebase/analytics": "0.10.0",
         "@firebase/analytics-compat": "0.2.6",
-        "@firebase/app": "0.9.19",
-        "@firebase/app-check": "0.8.0",
-        "@firebase/app-check-compat": "0.3.7",
-        "@firebase/app-compat": "0.2.19",
+        "@firebase/app": "0.9.25",
+        "@firebase/app-check": "0.8.1",
+        "@firebase/app-check-compat": "0.3.8",
+        "@firebase/app-compat": "0.2.25",
         "@firebase/app-types": "0.9.0",
-        "@firebase/auth": "1.3.0",
-        "@firebase/auth-compat": "0.4.6",
-        "@firebase/database": "1.0.1",
-        "@firebase/database-compat": "1.0.1",
-        "@firebase/firestore": "4.2.0",
-        "@firebase/firestore-compat": "0.3.18",
-        "@firebase/functions": "0.10.0",
-        "@firebase/functions-compat": "0.3.5",
+        "@firebase/auth": "1.5.1",
+        "@firebase/auth-compat": "0.5.1",
+        "@firebase/database": "1.0.2",
+        "@firebase/database-compat": "1.0.2",
+        "@firebase/firestore": "4.4.0",
+        "@firebase/firestore-compat": "0.3.23",
+        "@firebase/functions": "0.11.0",
+        "@firebase/functions-compat": "0.3.6",
         "@firebase/installations": "0.6.4",
         "@firebase/installations-compat": "0.2.4",
-        "@firebase/messaging": "0.12.4",
-        "@firebase/messaging-compat": "0.2.4",
+        "@firebase/messaging": "0.12.5",
+        "@firebase/messaging-compat": "0.2.5",
         "@firebase/performance": "0.6.4",
         "@firebase/performance-compat": "0.2.4",
         "@firebase/remote-config": "0.4.4",
         "@firebase/remote-config-compat": "0.2.4",
-        "@firebase/storage": "0.11.2",
-        "@firebase/storage-compat": "0.3.2",
+        "@firebase/storage": "0.12.0",
+        "@firebase/storage-compat": "0.3.3",
         "@firebase/util": "1.9.3"
       }
     },
@@ -9360,11 +9202,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
       "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ=="
-    },
-    "node_modules/fs-readdir-recursive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -13221,44 +13058,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -16290,11 +16089,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -16697,60 +16491,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/styled-components": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.0.8.tgz",
-      "integrity": "sha512-AwI02MTWZwqjzfXgR5QcbmcSn5xVjY4N2TLjSuYnmuBGF3y7GicHz3ysbpUq2EMJP5M8/Nc22vcmF3V3WNZDFA==",
-      "dependencies": {
-        "@babel/cli": "^7.21.0",
-        "@babel/core": "^7.21.0",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/plugin-external-helpers": "^7.18.6",
-        "@babel/plugin-proposal-class-properties": "^7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
-        "@babel/preset-env": "^7.20.2",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.21.0",
-        "@babel/traverse": "^7.21.2",
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@emotion/unitless": "^0.8.0",
-        "@types/stylis": "^4.0.2",
-        "css-to-react-native": "^3.2.0",
-        "csstype": "^3.1.2",
-        "postcss": "^8.4.23",
-        "shallowequal": "^1.1.0",
-        "stylis": "^4.3.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "babel-plugin-styled-components": ">= 2",
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-styled-components": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/styled-reset": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.5.1.tgz",
-      "integrity": "sha512-6EvFWZRwaFRFxiPYMwmnzOe33rDkw5r9jIU0eEi49bkt6VSrvjeMp2ZOw/YFbw5SVs81llIY+5fzHtR2/VBZfQ==",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "styled-components": ">=4.0.0 || >=5.0.0 || >=6.0.0"
-      }
-    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -16765,11 +16505,6 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/sucrase": {
       "version": "3.32.0",
@@ -17377,6 +17112,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
+      "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "firebase": "^10.4.0",
+    "firebase": "^10.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.13.0",

--- a/src/components/ControlMenu.js
+++ b/src/components/ControlMenu.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+const ControlMenu = React.memo(({ value, onChange, optionList }) => {
+  return (
+    <select
+      className="ControlMenu"
+      value={value}
+      name={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {optionList.map((it, idx) => (
+        <option key={idx} value={it.value}>
+          {it.name}
+        </option>
+      ))}
+    </select>
+  );
+});
+
+export default ControlMenu;

--- a/src/components/DiaryEditor.js
+++ b/src/components/DiaryEditor.js
@@ -8,6 +8,7 @@ import MyButton from "./MyButton";
 import MyHeader from "./MyHeader";
 import EmotionItem from "./EmotionItem";
 import Modal from "./Modal";
+import { useMoal } from "../hooks/useModal.js";
 
 const DiaryEditor = ({ isEdit, originData }) => {
   const contentRef = useRef();
@@ -15,10 +16,14 @@ const DiaryEditor = ({ isEdit, originData }) => {
   const [emotion, setEmotion] = useState(3);
   const [date, setDate] = useState(getStringDate(new Date()));
   const navigate = useNavigate();
-  const [openModal, setOpenModal] = useState(false);
-  const [modalStatus, setModalStatus] = useState("");
-  const [modalCheck, setModalCheck] = useState(false);
-
+  const {
+    isOpen,
+    toggleModal,
+    status,
+    setModalStatus,
+    userSelected,
+    setModalSelected,
+  } = useMoal();
   const { handleCreate, handleEdit, handleRemove } =
     useContext(DiaryDispatchContext);
   const handleClickEmote = useCallback((emotion) => {
@@ -26,7 +31,7 @@ const DiaryEditor = ({ isEdit, originData }) => {
   }, []);
 
   const handleModal = (modalState) => {
-    setOpenModal(modalState);
+    toggleModal(modalState);
   };
 
   const handleSubmit = () => {
@@ -35,35 +40,35 @@ const DiaryEditor = ({ isEdit, originData }) => {
       return;
     }
 
-    if (modalCheck) {
+    if (userSelected) {
       if (!isEdit) {
         handleCreate(date, content, emotion);
-        setModalCheck(false);
+        setModalSelected(false);
       } else {
         handleEdit(originData.diaryId, date, content, emotion);
-        setModalCheck(false);
+        setModalSelected(false);
       }
     }
     navigate("/home", { replace: true });
   };
 
   useEffect(() => {
-    if (modalCheck) {
-      if (modalStatus === "수정" || modalStatus === "작성") {
+    if (userSelected) {
+      if (status === "수정" || status === "작성") {
         handleSubmit();
-      } else if (modalStatus === "삭제") {
+      } else if (status === "삭제") {
         handleDiaryRemove();
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modalCheck, modalStatus]);
+  }, [userSelected, status]);
 
   const handleDiaryRemove = () => {
-    if (modalCheck) {
+    if (userSelected) {
       handleRemove(originData.diaryId, () => {
         navigate("/home", { replace: true });
       });
-      setModalCheck(false);
+      setModalSelected(false);
     }
   };
 
@@ -77,8 +82,8 @@ const DiaryEditor = ({ isEdit, originData }) => {
 
   return (
     <>
-      {openModal && (
-        <div className="Modal_Background" onClick={() => setOpenModal(false)} />
+      {isOpen && (
+        <div className="Modal_Background" onClick={() => toggleModal(false)} />
       )}
       <div className="DiaryEditor">
         <MyHeader
@@ -93,7 +98,7 @@ const DiaryEditor = ({ isEdit, originData }) => {
                 type={"negative"}
                 onClick={() => {
                   setModalStatus("삭제");
-                  setOpenModal(true);
+                  toggleModal(true);
                 }}
               />
             )
@@ -141,18 +146,18 @@ const DiaryEditor = ({ isEdit, originData }) => {
               text={isEdit ? "수정완료" : "작성완료"}
               type={"positive"}
               onClick={() => {
-                setOpenModal(true);
+                toggleModal(true);
                 setModalStatus(isEdit ? "수정" : "작성");
               }}
             />
           </div>
         </section>
-        {openModal && (
+        {isOpen && (
           <div className="Modal_Box">
             <Modal
               handleModal={handleModal}
-              modalStatus={modalStatus}
-              setModalCheck={setModalCheck}
+              status={status}
+              setModalSelected={setModalSelected}
             />
           </div>
         )}

--- a/src/components/DiaryEditor.js
+++ b/src/components/DiaryEditor.js
@@ -3,7 +3,6 @@ import { useState, useRef, useContext, useEffect, useCallback } from "react";
 import { DiaryDispatchContext } from "./../App.js";
 import { getStringDate } from "../utils/date.js";
 import { emotionList } from "../utils/emotion.js";
-
 import MyButton from "./MyButton";
 import MyHeader from "./MyHeader";
 import EmotionItem from "./EmotionItem";
@@ -16,6 +15,8 @@ const DiaryEditor = ({ isEdit, originData }) => {
   const [emotion, setEmotion] = useState(3);
   const [date, setDate] = useState(getStringDate(new Date()));
   const navigate = useNavigate();
+
+  // 모달 관련 로직
   const {
     isOpen,
     toggleModal,
@@ -24,16 +25,15 @@ const DiaryEditor = ({ isEdit, originData }) => {
     userSelected,
     setModalSelected,
   } = useMoal();
+
+  // 일기 CUD 관련 로직
   const { handleCreate, handleEdit, handleRemove } =
     useContext(DiaryDispatchContext);
   const handleClickEmote = useCallback((emotion) => {
     setEmotion(emotion);
   }, []);
 
-  const handleModal = (modalState) => {
-    toggleModal(modalState);
-  };
-
+  // 일기 작성 및 수정
   const handleSubmit = () => {
     if (content.legth < 1) {
       contentRef.current.focus();
@@ -52,6 +52,26 @@ const DiaryEditor = ({ isEdit, originData }) => {
     navigate("/home", { replace: true });
   };
 
+  // 일기 삭제
+  const handleDiaryRemove = () => {
+    if (userSelected) {
+      handleRemove(originData.diaryId, () => {
+        navigate("/home", { replace: true });
+      });
+      setModalSelected(false);
+    }
+  };
+
+  // 일기 수정일 때
+  useEffect(() => {
+    if (isEdit) {
+      setDate(getStringDate(new Date(parseInt(originData.date))));
+      setEmotion(originData.emotion);
+      setContent(originData.content);
+    }
+  }, [isEdit, originData]);
+
+  // 모달 status
   useEffect(() => {
     if (userSelected) {
       if (status === "수정" || status === "작성") {
@@ -62,23 +82,6 @@ const DiaryEditor = ({ isEdit, originData }) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userSelected, status]);
-
-  const handleDiaryRemove = () => {
-    if (userSelected) {
-      handleRemove(originData.diaryId, () => {
-        navigate("/home", { replace: true });
-      });
-      setModalSelected(false);
-    }
-  };
-
-  useEffect(() => {
-    if (isEdit) {
-      setDate(getStringDate(new Date(parseInt(originData.date))));
-      setEmotion(originData.emotion);
-      setContent(originData.content);
-    }
-  }, [isEdit, originData]);
 
   return (
     <>
@@ -155,7 +158,7 @@ const DiaryEditor = ({ isEdit, originData }) => {
         {isOpen && (
           <div className="Modal_Box">
             <Modal
-              handleModal={handleModal}
+              handleModal={(modalState) => toggleModal(modalState)}
               status={status}
               setModalSelected={setModalSelected}
             />

--- a/src/components/DiaryList.js
+++ b/src/components/DiaryList.js
@@ -4,29 +4,12 @@ import { useNavigate } from "react-router-dom";
 import DiaryItem from "./DiaryItem";
 import { sortOptionList, filterOptionList } from "../const/options";
 import { getProcessedDiaryList } from "../utils/filtersortList";
-
-const ControlMenu = React.memo(({ value, onChange, optionList }) => {
-  return (
-    <select
-      className="ControlMenu"
-      value={value}
-      name={value}
-      onChange={(e) => onChange(e.target.value)}
-    >
-      {optionList.map((it, idx) => (
-        <option key={idx} value={it.value}>
-          {it.name}
-        </option>
-      ))}
-    </select>
-  );
-});
+import ControlMenu from "./ControlMenu";
 
 const DiaryList = ({ diaryList }) => {
   const navigate = useNavigate();
   const [sortType, setSortType] = useState("latest");
   const [filter, setFilter] = useState("all");
-
   const processedDiaryList = getProcessedDiaryList(diaryList, filter, sortType);
 
   return (

--- a/src/components/DiaryList.js
+++ b/src/components/DiaryList.js
@@ -2,17 +2,8 @@ import React, { useState } from "react";
 import MyButton from "./MyButton";
 import { useNavigate } from "react-router-dom";
 import DiaryItem from "./DiaryItem";
-
-const sortOptionList = [
-  { value: "latest", name: "최신순" },
-  { value: "oldest", name: "오래된순" },
-];
-
-const filterOptionList = [
-  { value: "all", name: "전부 다" },
-  { value: "good", name: "좋은 감정만" },
-  { value: "bad", name: "안좋은 감정만" },
-];
+import { sortOptionList, filterOptionList } from "../const/options";
+import { getProcessedDiaryList } from "../utils/filtersortList";
 
 const ControlMenu = React.memo(({ value, onChange, optionList }) => {
   return (
@@ -36,40 +27,7 @@ const DiaryList = ({ diaryList }) => {
   const [sortType, setSortType] = useState("latest");
   const [filter, setFilter] = useState("all");
 
-  const getProcessedDiaryList = () => {
-    const filterCallback = (item) => {
-      if (filter === "good") {
-        return parseInt(item.emotion) <= 3;
-      } else {
-        return parseInt(item.emotion) > 3;
-      }
-    };
-
-    const compare = (a, b) => {
-      const dateSortBA = parseInt(b.date) - parseInt(a.date);
-      const dateSortAB = parseInt(a.date) - parseInt(b.date);
-      if (sortType === "latest") {
-        return dateSortBA === 0
-          ? parseInt(b.diaryId) - parseInt(a.diaryId)
-          : dateSortBA;
-      } else {
-        return dateSortAB === 0
-          ? parseInt(a.diaryId) - parseInt(b.diaryId)
-          : dateSortAB;
-      }
-    };
-
-    const copyList = JSON.parse(JSON.stringify(diaryList));
-
-    //오래된순, 최신순으로 정렬된 데이터를 또 필터링 해주기
-    //1,2,3 => good, | 4, 5 => bad
-
-    const filteredList =
-      filter === "all" ? copyList : copyList.filter((it) => filterCallback(it));
-
-    const sortedList = filteredList.sort(compare);
-    return sortedList;
-  };
+  const processedDiaryList = getProcessedDiaryList(diaryList, filter, sortType);
 
   return (
     <div className="DiaryList">
@@ -95,7 +53,7 @@ const DiaryList = ({ diaryList }) => {
         </div>
       </div>
 
-      {getProcessedDiaryList().map((it) => (
+      {processedDiaryList.map((it) => (
         <DiaryItem key={it.diaryId} {...it} />
       ))}
     </div>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,10 +1,10 @@
-function Modal({ handleModal, modalStatus, setModalCheck }) {
+function Modal({ handleModal, status, setModalSelected }) {
   return (
     <div className="Modal_Wrapper">
-      <p className="Modal_Text">일기를 {modalStatus}하시겠습니까?</p>
+      <p className="Modal_Text">일기를 {status}하시겠습니까?</p>
       <div className="Modal_Btn_Wrapper">
-        <button className="Modal_Btn" onClick={() => setModalCheck(true)}>
-          {modalStatus}
+        <button className="Modal_Btn" onClick={() => setModalSelected(true)}>
+          {status}
         </button>
         <button
           className="Modal_Btn"

--- a/src/const/options.js
+++ b/src/const/options.js
@@ -1,0 +1,10 @@
+export const sortOptionList = [
+  { value: "latest", name: "최신순" },
+  { value: "oldest", name: "오래된순" },
+];
+
+export const filterOptionList = [
+  { value: "all", name: "전부 다" },
+  { value: "good", name: "좋은 감정만" },
+  { value: "bad", name: "안좋은 감정만" },
+];

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+export const useMoal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [status, setStatus] = useState("");
+  const [userSelected, setUserSelected] = useState(false);
+
+  const toggleModal = () => setIsOpen(!isOpen);
+  const setModalStatus = (newStatus) => setStatus(newStatus);
+  const setModalSelected = (newCheck) => setUserSelected(newCheck);
+
+  return {
+    isOpen,
+    toggleModal,
+    status,
+    setModalStatus,
+    userSelected,
+    setModalSelected,
+  };
+};

--- a/src/utils/filtersortList.js
+++ b/src/utils/filtersortList.js
@@ -1,0 +1,31 @@
+export const getProcessedDiaryList = (diaryList, filter, sortType) => {
+  const filterCallback = (item) => {
+    if (filter === "good") {
+      return parseInt(item.emotion) <= 3;
+    } else {
+      return parseInt(item.emotion) > 3;
+    }
+  };
+
+  const compare = (a, b) => {
+    const dateSortBA = parseInt(b.date) - parseInt(a.date);
+    const dateSortAB = parseInt(a.date) - parseInt(b.date);
+    if (sortType === "latest") {
+      return dateSortBA === 0
+        ? parseInt(b.diaryId) - parseInt(a.diaryId)
+        : dateSortBA;
+    } else {
+      return dateSortAB === 0
+        ? parseInt(a.diaryId) - parseInt(b.diaryId)
+        : dateSortAB;
+    }
+  };
+
+  const copyList = JSON.parse(JSON.stringify(diaryList));
+
+  const filteredList =
+    filter === "all" ? copyList : copyList.filter((it) => filterCallback(it));
+
+  const sortedList = filteredList.sort(compare);
+  return sortedList;
+};


### PR DESCRIPTION
**리팩토링 목적**
이전 PR 때 놓쳤던 컴포넌트들을 대상으로 비즈니스 로직 분리 및 커스텀 훅 생성 작업을 추가로 하였다.

**구현한 기능**

*DiaryList 페이지 함수 분리*
-  상수 const폴더로 분리
-  getProcessedDiary 함수 분리
-  useModal 커스텀 훅 생성 및 모달 로직 분리
- ControlMenu 컴포넌트 분리

*그 외 페이지 전반적으로 코드 분리*


**어려웠던 점**
재사용을 하지 않는 함수를 분리하는게 옳을지, 코드를 남겨놓는게 좋을지 고민을 많이 했다. 대체로 분리하는 쪽을 선택했으나 코드가 짧거나 `useEffect`로 관리되는 로직들은 원래 컴포넌트에 남겨두었고 그 외 비즈니스 로직은 대부분 분리하였다.
+
지난번 PR 때는 전에 설정해둔 것때문인지 자동으로 Github Actions에서 npm ci && npm build를 해주었는데 에러가 발생했다. 자동 ci 및 build를 해줄 지 모르고 따로 .env 안에 있는 API key 등을 등록해놓지 않았고, firebase-hosting.yml도 설정하지 않았기 때문이다. 현재는 설정을 해주었는데 지금 pr 때 과연 자동 ci와 build가 성공할지가 궁금하다.