### PR TITLE
[#7][BugFix] Home 페이지에서 새로고침 시 계속 Login 페이지로 이동하는 문제 해결

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,12 +1,10 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 
 export const useAuth = () => {
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
+  const [user, setUser] = useState(() => {
     const loginedUser = localStorage.getItem("kakao_email");
-    setUser(loginedUser);
-  }, []);
+    return loginedUser;
+  });
 
   const updateUser = useCallback((email) => {
     if (email) {


### PR DESCRIPTION
🚨 문제 상황
성능 테스트를 진행하려는데 Home 페이지에서 새로고침 시 계속 Login 페이지로 이동함.

🚩 문제 원인
useEffect 내에서 로그인한 유저의 상태를 확인하는 로직이 비동기적으로 작동하기 때문임. 페이지가 로드될 때 user 상태가 초기엔 null로 설정되어 있으며 로컬 스토리지에서 유저 상태를 가져오는 것은 비동기적으로 이루어지고 있음. 페이지 로드시 user의 상태를 null로 판단하고, 설정에 따라 Login 페이지로 리디렉션하고 있는 것임.

✔ 해결 방안
useAuth에서 user 상태롤 초기화하는 방식을 수정함. user 상태를 동기적으로 초기화하여 컴포넌트가 마운트 될 때 바로 확인할 수 있도록 수정하였음.

```js
  const [user, setUser] = useState(() => {
    const loginedUser = localStorage.getItem("kakao_email");
    return loginedUser;
  });

```